### PR TITLE
Hmm import error

### DIFF
--- a/nltk_contrib/coref/api.py
+++ b/nltk_contrib/coref/api.py
@@ -354,3 +354,4 @@ class AbstractClassifierBasedTagger(ClassifierBasedTagger, ClassifierI,
         if test_sequence:
             classifier.test(test_sequence)
         return classifier
+


### PR DESCRIPTION
It seems that HiddenMarkovModelTaggerTransformI is not accessible anymore under nltk.tag. I changed the path of the import to the new location under nltk.tag.hmm
