### PR TITLE
Add preference for setuptools with distutils fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,12 @@
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 import nltk
 
 setup(
@@ -17,7 +22,7 @@ setup(
     ## Distribution Metadata
     name = "nltk_contrib",
     description = "NLTK-Contrib",
-    
+
     version = nltk.__version__,
     url = nltk.__url__,
     long_description = nltk.__longdescr__,
@@ -28,7 +33,7 @@ setup(
     author = nltk.__author__,
     author_email = nltk.__author__,
     # platforms = <platforms>,
-    
+
     #############################################
     ## Package List
     packages = ['nltk_contrib',


### PR DESCRIPTION
This pull request adds setuptools import to setup.py, with distutils as a fallback. That makes it possible to run ``setup.py develop``.